### PR TITLE
Mark some scripts as temporary

### DIFF
--- a/src/batching/hackingDaemon.ts
+++ b/src/batching/hackingDaemon.ts
@@ -236,7 +236,7 @@ async function runTask(
   });
   if (candidateServers.length === 0) return false;
   await ns.scp(script, candidateServers[0]);
-  const pid = ns.exec(script, candidateServers[0], 1, ...args);
+  const pid = ns.exec(script, candidateServers[0], {threads: 1, temporary: true}, ...args);
   if (pid === 0) {
     logging.error(`Failed to run ${script} on ${candidateServers[0]}`);
     return false;

--- a/src/contracts/contractTesting.ts
+++ b/src/contracts/contractTesting.ts
@@ -1,0 +1,18 @@
+import { NS } from '@ns';
+import { Game } from '/lib/game';
+import { solveContractPath } from '/contracts/solveContract';
+
+export const contractTestingPath ="/contracts/contractTesting.js";
+
+export async function main(ns : NS) : Promise<void> {
+  const game = new Game(ns);
+  
+  const contractTypes = ns.codingcontract.getContractTypes();
+  contractTypes.forEach(type =>{
+    const contractFilename = ns.codingcontract.createDummyContract(type);
+    ns.exec(solveContractPath,"home",{},contractFilename, "home");
+  })
+
+
+
+}

--- a/src/contracts/unsolveableContract.ts
+++ b/src/contracts/unsolveableContract.ts
@@ -22,17 +22,18 @@ export async function main(ns: NS): Promise<void> {
     logging.warning("contract missing.");
     ns.exit();
   }
-
-  const contractDesc = ns.codingcontract.getDescription(filename, host);
-  const contractData = ns.codingcontract.getData(filename, host);
-  const contractType = ns.codingcontract.getContractType(filename, host);
+  const contractInfo = {
+    description: ns.codingcontract.getDescription(filename, host),
+    type: ns.codingcontract.getContractType(filename, host),
+    data: ns.codingcontract.getData(filename, host),
+  }
   if (!ns.rm(filename, host)) {
     logging.info(`unable to delete ${host}:${filename}`);
   }
 
   await ns.write(
     `/failedContracts/${filename.replace("cct", "txt").replace("'", "_").replace("&", "_")}`,
-    [contractType, contractData, contractDesc].join("\n\n"),
+    JSON.stringify(contractInfo,undefined,2),
     "w",
   );
 }

--- a/src/cron/triggerJob.ts
+++ b/src/cron/triggerJob.ts
@@ -23,7 +23,7 @@ export async function main(ns: NS): Promise<void> {
   ns.print(`setting up cronjob: ${script}`);
   await ns.sleep(Math.random() * interval);
   while (interval && script) {
-    const pid = ns.run(script, 1, ...args);
+    const pid = ns.run(script, {threads:1, temporary:true}, ...args);
 
     if (pid === 0) {
       ns.print(`failed to start script.`);


### PR DESCRIPTION
- unsolved contracts are saved as a json object.
- run a test of our contract solvers.
- Mark certain jobs as temporary to not clutter the killed script list.
